### PR TITLE
Remove dependency on human-only resources files

### DIFF
--- a/all_of_us/ancestry/determine_hq_sites_intersection.wdl
+++ b/all_of_us/ancestry/determine_hq_sites_intersection.wdl
@@ -178,7 +178,7 @@ task sitesOnlyAndHQFilterVcf {
     runtime {
         docker:"us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "12 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }
@@ -244,7 +244,7 @@ task merge_vcf_bgzs {
     runtime {
         docker: "mgibio/bcftools-cwl:1.12"
         memory: "100 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk 1500 HDD"
         bootDiskSizeGb: 1500
     }
@@ -302,7 +302,7 @@ task filter_by_sites_only {
     runtime {
         docker:"us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "3 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk 100 HDD"
     }
 }
@@ -338,7 +338,7 @@ task intersect_vcfs_as_sites_only {
     runtime {
         docker: "us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "3 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk 500 HDD"
     }
 }

--- a/all_of_us/ancestry/run_ancestry.wdl
+++ b/all_of_us/ancestry/run_ancestry.wdl
@@ -161,7 +161,7 @@ task create_hw_pca_training {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "123 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 500 HDD"
     }
 }
@@ -280,7 +280,7 @@ task call_ancestry {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "240 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 700 HDD"
     }
 }
@@ -377,7 +377,7 @@ task plot_ancestry {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "7 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }

--- a/all_of_us/ancestry/vds_to_vcf.wdl
+++ b/all_of_us/ancestry/vds_to_vcf.wdl
@@ -248,7 +248,7 @@ task process_vds {
     runtime {
         docker: "hailgenetics/hail:0.2.127-py3.11"
         memory: "624 GB"
-        cpu: "96"
+        cpu: 96
         disks: "local-disk 1000 HDD"
         bootDiskSizeGb: 500
     }
@@ -274,7 +274,7 @@ task create_fofn {
     runtime {
         docker: "us.gcr.io/broad-gatk/gatk:4.2.6.1"
         memory: "3 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk 100 HDD"
     }
 }

--- a/all_of_us/rna_seq/markduplicates.wdl
+++ b/all_of_us/rna_seq/markduplicates.wdl
@@ -32,7 +32,7 @@ task markduplicates {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: ${num_threads}
         preemptible: "${num_preempt}"
     }
 

--- a/all_of_us/rna_seq/remove_IDS_reads.wdl
+++ b/all_of_us/rna_seq/remove_IDS_reads.wdl
@@ -22,7 +22,7 @@ task remove_IDS_reads {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: ${num_threads}
         preemptible: "${num_preempt}"
     }
 

--- a/all_of_us/rna_seq/rnaseqc2.wdl
+++ b/all_of_us/rna_seq/rnaseqc2.wdl
@@ -38,7 +38,7 @@ task rnaseqc2 {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: ${num_threads}
         preemptible: "${num_preempt}"
     }
 

--- a/all_of_us/rna_seq/rsem.wdl
+++ b/all_of_us/rna_seq/rsem.wdl
@@ -38,7 +38,7 @@ task rsem {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: ${num_threads}
         preemptible: "${num_preempt}"
     }
 

--- a/all_of_us/rna_seq/samtofastq.wdl
+++ b/all_of_us/rna_seq/samtofastq.wdl
@@ -34,7 +34,7 @@ task samtofastq {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: ${num_threads}
         preemptible: "${num_preempt}"
     }
 

--- a/all_of_us/rna_seq/star.wdl
+++ b/all_of_us/rna_seq/star.wdl
@@ -132,7 +132,7 @@ task star {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq@sha256:80c2db3cec3c08630237665e2d2f044f065022e0bbf7a62d0765f51f811818e2"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: ${num_threads}
         preemptible: "${num_preempt}"
     }
 

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
@@ -1,7 +1,6 @@
 version 1.0
 
 import "../../../../../tasks/broad/JointGenotypingTasks.wdl" as Tasks
-import "https://raw.githubusercontent.com/broadinstitute/gatk/4.5.0.0/scripts/vcf_site_level_filtering_wdl/JointVcfFiltering.wdl" as Filtering
 
 
 # Joint Genotyping for hg38 Whole Genomes and Exomes (has not been tested on hg19)
@@ -19,57 +18,26 @@ workflow JointGenotyping {
     File ref_fasta_index
     File ref_dict
 
-    File dbsnp_vcf
-    File dbsnp_vcf_index
+    File empty_dbsnp_vcf
+    File empty_dbsnp_vcf_index
 
     Int small_disk
     Int medium_disk
     Int large_disk
     Int huge_disk
 
-    Array[String]? snp_recalibration_tranche_values
-    Array[String] snp_recalibration_annotation_values
-    Array[String]? indel_recalibration_tranche_values
-    Array[String]? indel_recalibration_annotation_values
-
-    File haplotype_database
-
     File eval_interval_list
-    File hapmap_resource_vcf
-    File hapmap_resource_vcf_index
-    File omni_resource_vcf
-    File omni_resource_vcf_index
-    File one_thousand_genomes_resource_vcf
-    File one_thousand_genomes_resource_vcf_index
-    File mills_resource_vcf
-    File mills_resource_vcf_index
-    File axiomPoly_resource_vcf
-    File axiomPoly_resource_vcf_index
-    File dbsnp_resource_vcf = dbsnp_vcf
-    File dbsnp_resource_vcf_index = dbsnp_vcf_index
 
     # ExcessHet is a phred-scaled p-value. We want a cutoff of anything more extreme
     # than a z-score of -4.5 which is a p-value of 3.4e-06, which phred-scaled is 54.69
     Float excess_het_threshold = 54.69
-    Float? vqsr_snp_filter_level
-    Float? vqsr_indel_filter_level
-    Int? snp_vqsr_downsampleFactor
+
     File? targets_interval_list
 
     Int? top_level_scatter_count
     Boolean? gather_vcfs
-    Int snps_variant_recalibration_threshold = 500000
-    Boolean rename_gvcf_samples = true
     Float unbounded_scatter_count_scale_factor = 0.15
-    Int gnarly_scatter_count = 10
-    Boolean use_gnarly_genotyper = false
-    Boolean use_allele_specific_annotations = true # only applicabale to VQSR
-    Boolean cross_check_fingerprints = true
-    Boolean scatter_cross_check_fingerprints = false
-    Boolean run_vets = false
   }
-
-  Boolean allele_specific_annotations = !use_gnarly_genotyper && use_allele_specific_annotations
 
   Array[Array[String]] sample_name_map_lines = read_tsv(sample_name_map)
   Int num_gvcfs = length(sample_name_map_lines)
@@ -123,60 +91,19 @@ workflow JointGenotyping {
         batch_size = 50
     }
 
-    if (use_gnarly_genotyper) {
-
-      call Tasks.SplitIntervalList as GnarlyIntervalScatterDude {
-        input:
-          interval_list = unpadded_intervals[idx],
-          scatter_count = gnarly_scatter_count,
-          ref_fasta = ref_fasta,
-          ref_fasta_index = ref_fasta_index,
-          ref_dict = ref_dict,
-          disk_size_gb = small_disk,
-          sample_names_unique_done = CheckSamplesUnique.samples_unique
-      }
-
-      Array[File] gnarly_intervals = GnarlyIntervalScatterDude.output_intervals
-
-      scatter (gnarly_idx in range(length(gnarly_intervals))) {
-        call Tasks.GnarlyGenotyper {
-          input:
-            workspace_tar = ImportGVCFs.output_genomicsdb,
-            interval = gnarly_intervals[gnarly_idx],
-            output_vcf_filename = callset_name + "." + idx + "." + gnarly_idx + ".vcf.gz",
-            ref_fasta = ref_fasta,
-            ref_fasta_index = ref_fasta_index,
-            ref_dict = ref_dict,
-            dbsnp_vcf = dbsnp_vcf,
-        }
-      }
-
-      Array[File] gnarly_gvcfs = GnarlyGenotyper.output_vcf
-
-      call Tasks.GatherVcfs as TotallyRadicalGatherVcfs {
-        input:
-          input_vcfs = gnarly_gvcfs,
-          output_vcf_name = callset_name + "." + idx + ".gnarly.vcf.gz",
-          disk_size_gb = large_disk
-      }
+    call Tasks.GenotypeGVCFs {
+    input:
+        workspace_tar = ImportGVCFs.output_genomicsdb,
+        interval = unpadded_intervals[idx],
+        output_vcf_filename = callset_name + "." + idx + ".vcf.gz",
+        ref_fasta = ref_fasta,
+        ref_fasta_index = ref_fasta_index,
+        ref_dict = ref_dict,
+        disk_size_gb = medium_disk
     }
 
-    if (!use_gnarly_genotyper) {
-      call Tasks.GenotypeGVCFs {
-        input:
-          workspace_tar = ImportGVCFs.output_genomicsdb,
-          interval = unpadded_intervals[idx],
-          output_vcf_filename = callset_name + "." + idx + ".vcf.gz",
-          ref_fasta = ref_fasta,
-          ref_fasta_index = ref_fasta_index,
-          ref_dict = ref_dict,
-          dbsnp_vcf = dbsnp_vcf,
-          disk_size_gb = medium_disk
-      }
-    }
-
-    File genotyped_vcf = select_first([TotallyRadicalGatherVcfs.output_vcf, GenotypeGVCFs.output_vcf])
-    File genotyped_vcf_index = select_first([TotallyRadicalGatherVcfs.output_vcf_index, GenotypeGVCFs.output_vcf_index])
+    File genotyped_vcf = GenotypeGVCFs.output_vcf
+    File genotyped_vcf_index = GenotypeGVCFs.output_vcf_index
 
     call Tasks.HardFilterAndMakeSitesOnlyVcf {
       input:
@@ -190,153 +117,8 @@ workflow JointGenotyping {
     }
   }
 
-  call Tasks.GatherVcfs as SitesOnlyGatherVcf {
-    input:
-      input_vcfs = HardFilterAndMakeSitesOnlyVcf.sites_only_vcf,
-      output_vcf_name = callset_name + ".sites_only.vcf.gz",
-      disk_size_gb = medium_disk
-  }
-  
-  if (run_vets) {
-    String resource_args = " --resource:hapmap,training=true,calibration=true " + hapmap_resource_vcf + 
-      " --resource:omni,training=true,calibration=true " + omni_resource_vcf + 
-      " --resource:1000G,training=true " + one_thousand_genomes_resource_vcf +
-      " --resource:mills,training=true,calibration=true " + mills_resource_vcf + " "
-    String extract_extra_args = if defined(targets_interval_list) then " -L " + targets_interval_list + " " else "" #only train the model over the targets, apply the model to everything
-
-    call Filtering.JointVcfFiltering as TrainAndApplyVETS {
-      input:
-        input_vcfs = HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf,
-        input_vcf_idxs = HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf_index,
-        sites_only_vcf = SitesOnlyGatherVcf.output_vcf,
-        sites_only_vcf_idx = SitesOnlyGatherVcf.output_vcf_index,
-        annotations = snp_recalibration_annotation_values, #the snp list here is a superset of  the indel list
-        extract_extra_args = extract_extra_args,
-        resource_args = resource_args,
-        output_prefix = callset_name,
-        gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
-    }
-  } 
-  if (!run_vets) {
-    call Tasks.IndelsVariantRecalibrator {
-      input:
-        sites_only_variant_filtered_vcf = SitesOnlyGatherVcf.output_vcf,
-        sites_only_variant_filtered_vcf_index = SitesOnlyGatherVcf.output_vcf_index,
-        recalibration_filename = callset_name + ".indels.recal",
-        tranches_filename = callset_name + ".indels.tranches",
-        recalibration_tranche_values = select_first([indel_recalibration_tranche_values]),
-        recalibration_annotation_values = select_first([indel_recalibration_annotation_values]),
-        mills_resource_vcf = mills_resource_vcf,
-        mills_resource_vcf_index = mills_resource_vcf_index,
-        axiomPoly_resource_vcf = axiomPoly_resource_vcf,
-        axiomPoly_resource_vcf_index = axiomPoly_resource_vcf_index,
-        dbsnp_resource_vcf = dbsnp_resource_vcf,
-        dbsnp_resource_vcf_index = dbsnp_resource_vcf_index,
-        use_allele_specific_annotations = allele_specific_annotations,
-        disk_size_gb = small_disk
-    }
-
-    if (num_gvcfs > snps_variant_recalibration_threshold) {
-      call Tasks.SNPsVariantRecalibratorCreateModel {
-        input:
-          sites_only_variant_filtered_vcf = SitesOnlyGatherVcf.output_vcf,
-          sites_only_variant_filtered_vcf_index = SitesOnlyGatherVcf.output_vcf_index,
-          recalibration_filename = callset_name + ".snps.recal",
-          tranches_filename = callset_name + ".snps.tranches",
-          recalibration_tranche_values = select_first([snp_recalibration_tranche_values]),
-          recalibration_annotation_values = snp_recalibration_annotation_values,
-          downsampleFactor = select_first([snp_vqsr_downsampleFactor]),
-          model_report_filename = callset_name + ".snps.model.report",
-          hapmap_resource_vcf = hapmap_resource_vcf,
-          hapmap_resource_vcf_index = hapmap_resource_vcf_index,
-          omni_resource_vcf = omni_resource_vcf,
-          omni_resource_vcf_index = omni_resource_vcf_index,
-          one_thousand_genomes_resource_vcf = one_thousand_genomes_resource_vcf,
-          one_thousand_genomes_resource_vcf_index = one_thousand_genomes_resource_vcf_index,
-          dbsnp_resource_vcf = dbsnp_resource_vcf,
-          dbsnp_resource_vcf_index = dbsnp_resource_vcf_index,
-          use_allele_specific_annotations = allele_specific_annotations,
-          disk_size_gb = small_disk
-      }
-
-      scatter (idx in range(length(HardFilterAndMakeSitesOnlyVcf.sites_only_vcf))) {
-        call Tasks.SNPsVariantRecalibrator as SNPsVariantRecalibratorScattered {
-          input:
-            sites_only_variant_filtered_vcf = HardFilterAndMakeSitesOnlyVcf.sites_only_vcf[idx],
-            sites_only_variant_filtered_vcf_index = HardFilterAndMakeSitesOnlyVcf.sites_only_vcf_index[idx],
-            recalibration_filename = callset_name + ".snps." + idx + ".recal",
-            tranches_filename = callset_name + ".snps." + idx + ".tranches",
-            recalibration_tranche_values = select_first([snp_recalibration_tranche_values]),
-            recalibration_annotation_values = snp_recalibration_annotation_values,
-            model_report = SNPsVariantRecalibratorCreateModel.model_report,
-            hapmap_resource_vcf = hapmap_resource_vcf,
-            hapmap_resource_vcf_index = hapmap_resource_vcf_index,
-            omni_resource_vcf = omni_resource_vcf,
-            omni_resource_vcf_index = omni_resource_vcf_index,
-            one_thousand_genomes_resource_vcf = one_thousand_genomes_resource_vcf,
-            one_thousand_genomes_resource_vcf_index = one_thousand_genomes_resource_vcf_index,
-            dbsnp_resource_vcf = dbsnp_resource_vcf,
-            dbsnp_resource_vcf_index = dbsnp_resource_vcf_index,
-            use_allele_specific_annotations = allele_specific_annotations,
-            disk_size_gb = small_disk
-          }
-      }
-
-      call Tasks.GatherTranches as SNPGatherTranches {
-        input:
-          tranches = SNPsVariantRecalibratorScattered.tranches,
-          output_filename = callset_name + ".snps.gathered.tranches",
-          mode = "SNP",
-          disk_size_gb = small_disk
-      }
-    }
-
-    if (num_gvcfs <= snps_variant_recalibration_threshold) {
-      call Tasks.SNPsVariantRecalibrator as SNPsVariantRecalibratorClassic {
-        input:
-          sites_only_variant_filtered_vcf = SitesOnlyGatherVcf.output_vcf,
-          sites_only_variant_filtered_vcf_index = SitesOnlyGatherVcf.output_vcf_index,
-          recalibration_filename = callset_name + ".snps.recal",
-          tranches_filename = callset_name + ".snps.tranches",
-          recalibration_tranche_values = select_first([snp_recalibration_tranche_values]),
-          recalibration_annotation_values = snp_recalibration_annotation_values,
-          hapmap_resource_vcf = hapmap_resource_vcf,
-          hapmap_resource_vcf_index = hapmap_resource_vcf_index,
-          omni_resource_vcf = omni_resource_vcf,
-          omni_resource_vcf_index = omni_resource_vcf_index,
-          one_thousand_genomes_resource_vcf = one_thousand_genomes_resource_vcf,
-          one_thousand_genomes_resource_vcf_index = one_thousand_genomes_resource_vcf_index,
-          dbsnp_resource_vcf = dbsnp_resource_vcf,
-          dbsnp_resource_vcf_index = dbsnp_resource_vcf_index,
-          use_allele_specific_annotations = allele_specific_annotations,
-          disk_size_gb = small_disk
-      }
-    }
-
-    scatter (idx in range(length(HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf))) {
-      #for really large callsets we give to friends, just apply filters to the sites-only
-      call Tasks.ApplyRecalibration {
-        input:
-          recalibrated_vcf_filename = callset_name + ".filtered." + idx + ".vcf.gz",
-          input_vcf = HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf[idx],
-          input_vcf_index = HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf_index[idx],
-          indels_recalibration = IndelsVariantRecalibrator.recalibration,
-          indels_recalibration_index = IndelsVariantRecalibrator.recalibration_index,
-          indels_tranches = IndelsVariantRecalibrator.tranches,
-          snps_recalibration = if defined(SNPsVariantRecalibratorScattered.recalibration) then select_first([SNPsVariantRecalibratorScattered.recalibration])[idx] else select_first([SNPsVariantRecalibratorClassic.recalibration]),
-          snps_recalibration_index = if defined(SNPsVariantRecalibratorScattered.recalibration_index) then select_first([SNPsVariantRecalibratorScattered.recalibration_index])[idx] else select_first([SNPsVariantRecalibratorClassic.recalibration_index]),
-          snps_tranches = select_first([SNPGatherTranches.tranches_file, SNPsVariantRecalibratorClassic.tranches]),
-          indel_filter_level = select_first([vqsr_indel_filter_level]),
-          snp_filter_level = select_first([vqsr_snp_filter_level]),
-          use_allele_specific_annotations = allele_specific_annotations,
-          disk_size_gb = medium_disk
-      }
-    }
-  }
-
-  Array[File] filtered_vcfs = select_first([ApplyRecalibration.recalibrated_vcf, TrainAndApplyVETS.scored_vcfs])
-  Array[File] filtered_vcf_idxs = select_first([ApplyRecalibration.recalibrated_vcf_index, TrainAndApplyVETS.scored_vcf_idxs])
-
+  Array[File] filtered_vcfs = HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf
+  Array[File] filtered_vcf_idxs = HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf_index
   if (!is_small_callset) {
     scatter (idx in range(length(filtered_vcfs))) {
     # For large callsets we need to collect metrics from the shards and gather them later.
@@ -345,8 +127,8 @@ workflow JointGenotyping {
           input_vcf = filtered_vcfs[idx],
           input_vcf_index = filtered_vcf_idxs[idx],
           metrics_filename_prefix = callset_name + "." + idx,
-          dbsnp_vcf = dbsnp_vcf,
-          dbsnp_vcf_index = dbsnp_vcf_index,
+          dbsnp_vcf = empty_dbsnp_vcf,
+          dbsnp_vcf_index = empty_dbsnp_vcf_index,
           interval_list = eval_interval_list,
           ref_dict = ref_dict,
           disk_size_gb = medium_disk
@@ -376,90 +158,12 @@ workflow JointGenotyping {
         input_vcf = FinalGatherVcf.output_vcf,
         input_vcf_index = FinalGatherVcf.output_vcf_index,
         metrics_filename_prefix = callset_name,
-        dbsnp_vcf = dbsnp_vcf,
-        dbsnp_vcf_index = dbsnp_vcf_index,
+        dbsnp_vcf = empty_dbsnp_vcf,
+        dbsnp_vcf_index = empty_dbsnp_vcf_index,
         interval_list = eval_interval_list,
         ref_dict = ref_dict,
         disk_size_gb = large_disk
     }
-  }
-
-  # CrossCheckFingerprints takes forever on large callsets.
-  # We scatter over the input GVCFs to make things faster.
-if (cross_check_fingerprints) {
-  if (scatter_cross_check_fingerprints) {
-    call Tasks.GetFingerprintingIntervalIndices {
-      input:
-        unpadded_intervals = unpadded_intervals,
-        haplotype_database = haplotype_database
-    }
-
-    Array[Int] fingerprinting_indices = GetFingerprintingIntervalIndices.indices_to_fingerprint
-
-    scatter (idx in fingerprinting_indices) {
-      File vcfs_to_fingerprint = HardFilterAndMakeSitesOnlyVcf.variant_filtered_vcf[idx]
-    }
-
-    call Tasks.GatherVcfs as GatherFingerprintingVcfs {
-      input:
-        input_vcfs = vcfs_to_fingerprint,
-        output_vcf_name = callset_name + ".gathered.fingerprinting.vcf.gz",
-        disk_size_gb = medium_disk
-    }
-
-    call Tasks.SelectFingerprintSiteVariants {
-      input:
-        input_vcf = GatherFingerprintingVcfs.output_vcf,
-        base_output_name = callset_name + ".fingerprinting",
-        haplotype_database = haplotype_database,
-        disk_size_gb = medium_disk
-    }
-
-    call Tasks.PartitionSampleNameMap {
-      input:
-        sample_name_map = sample_name_map,
-        line_limit = 1000
-    }
-
-    scatter (idx in range(length(PartitionSampleNameMap.partitions))) {
-
-      Array[File] files_in_partition = read_lines(PartitionSampleNameMap.partitions[idx])
-
-      call Tasks.CrossCheckFingerprint as CrossCheckFingerprintsScattered {
-        input:
-          gvcf_paths = files_in_partition,
-          vcf_paths = vcfs_to_fingerprint,
-          sample_name_map = sample_name_map,
-          haplotype_database = haplotype_database,
-          output_base_name = callset_name + "." + idx,
-          scattered = true
-      }
-    }
-
-    call Tasks.GatherPicardMetrics as GatherFingerprintingMetrics {
-      input:
-        metrics_files = CrossCheckFingerprintsScattered.crosscheck_metrics,
-        output_file_name = callset_name + ".fingerprintcheck",
-        disk_size_gb = small_disk
-    }
-  }
-
-  if (!scatter_cross_check_fingerprints) {
-
-    scatter (line in sample_name_map_lines) {
-      File gvcf_paths = line[1]
-    }
-
-    call Tasks.CrossCheckFingerprint as CrossCheckFingerprintSolo {
-      input:
-        gvcf_paths = gvcf_paths,
-        vcf_paths = filtered_vcfs,
-        sample_name_map = sample_name_map,
-        haplotype_database = haplotype_database,
-        output_base_name = callset_name
-      }
-    }
-    File crosscheck_fingerprint_results = select_first([CrossCheckFingerprintSolo.crosscheck_metrics, GatherFingerprintingMetrics.gathered_metrics])
   }
 
   # Get the metrics from either code path
@@ -481,9 +185,6 @@ if (cross_check_fingerprints) {
 
     # Output the interval list generated/used by this run workflow.
     Array[File] output_intervals = SplitIntervalList.output_intervals
-
-    # Output the metrics from crosschecking fingerprints.
-    File? crosscheck_fingerprint_check = crosscheck_fingerprint_results
   }
   meta {
     allowNestedInputs: true

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
@@ -113,7 +113,6 @@ workflow VariantCalling {
           ref_dict = ref_dict,
           ref_fasta = ref_fasta,
           ref_fasta_index = ref_fasta_index,
-          contamination = contamination,
           preemptible_tries = agg_preemptible_tries,
           hc_scatter = hc_divisor,
           docker = gatk_1_3_docker
@@ -210,8 +209,6 @@ workflow VariantCalling {
     input:
       input_vcf = select_first([Reblock.output_vcf, MergeVCFs.output_vcf]),
       input_vcf_index = select_first([Reblock.output_vcf_index, MergeVCFs.output_vcf_index]),
-      dbsnp_vcf = dbsnp_vcf,
-      dbsnp_vcf_index = dbsnp_vcf_index,
       ref_fasta = ref_fasta,
       ref_fasta_index = ref_fasta_index,
       ref_dict = ref_dict,

--- a/pipelines/skylab/build_indices/BuildIndices.wdl
+++ b/pipelines/skylab/build_indices/BuildIndices.wdl
@@ -83,7 +83,7 @@ task CalculateChromosomeSizes {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: 3
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 50 HDD"
   }
   output {
@@ -229,7 +229,7 @@ String reference_name = "bwa-mem2-2.2.1-~{organism}-~{genome_source}-build-~{gen
     memory: "96GB"
     disks: "local-disk 100 HDD"
     disk: "100 GB" # TES
-    cpu: "4"
+    cpu: 4
   }
 
   output {
@@ -291,7 +291,7 @@ task RecordMetadata {
     docker: "ubuntu:20.04"
     memory: "5 GiB"
     disks: "local-disk 100 HDD"
-    cpu: "1"
+    cpu: 1
   }
 }
 

--- a/tasks/broad/Alignment.wdl
+++ b/tasks/broad/Alignment.wdl
@@ -116,7 +116,7 @@ task SamToFastqAndBwaMemAndMba {
     docker: "us.gcr.io/broad-gotc-prod/samtools-picard-bwa:1.0.2-0.7.15-2.26.10-1643840748"
     preemptible: preemptible_tries
     memory: "14 GiB"
-    cpu: "16"
+    cpu: 16
     disks: "local-disk " + disk_size + " HDD"
   }
   output {

--- a/tasks/broad/BamProcessing.wdl
+++ b/tasks/broad/BamProcessing.wdl
@@ -50,7 +50,7 @@ task SortSam {
   runtime {
     docker: docker
     disks: "local-disk " + disk_size + " HDD"
-    cpu: "1"
+    cpu: 1
     memory: "${machine_mem_mb} MiB"
     preemptible: preemptible_tries
   }

--- a/tasks/broad/CopyFilesFromCloudToCloud.wdl
+++ b/tasks/broad/CopyFilesFromCloudToCloud.wdl
@@ -68,7 +68,7 @@ task CopyFilesFromCloudToCloud {
   # We don't have to use an external IP.
   runtime {
     memory: "2 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 20 HDD"
     docker: "us.gcr.io/broad-gotc-prod/dsde-toolbox:stable_04-18-2022"
     preemptible: 3

--- a/tasks/broad/GermlineVariantDiscovery.wdl
+++ b/tasks/broad/GermlineVariantDiscovery.wdl
@@ -71,7 +71,7 @@ task HaplotypeCaller_GATK35_GVCF {
     docker: docker
     preemptible: preemptible_tries
     memory: "10000 MiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
@@ -162,7 +162,7 @@ task HaplotypeCaller_GATK4_VCF {
     docker: gatk_docker
     preemptible: preemptible_tries
     memory: "~{memory_size_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -378,7 +378,7 @@ task CNNScoreVariants {
     docker: gatk_docker
     preemptible: preemptible_tries
     memory: "15000 MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -434,7 +434,7 @@ task FilterVariantTranches {
 
   runtime {
     memory: "7000 MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
     preemptible: preemptible_tries

--- a/tasks/broad/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/broad/IlluminaGenotypingArrayTasks.wdl
@@ -538,7 +538,7 @@ task MergePedIntoVcf {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.11"
     memory: "3500 MiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     preemptible: preemptible_tries
   }

--- a/tasks/broad/JointGenotypingTasks.wdl
+++ b/tasks/broad/JointGenotypingTasks.wdl
@@ -150,7 +150,7 @@ task GenotypeGVCFs {
     File ref_fasta_index
     File ref_dict
 
-    String dbsnp_vcf
+    String? dbsnp_vcf
 
     Boolean keep_combined_raw_annotations = false
     String? additional_annotation
@@ -178,7 +178,7 @@ task GenotypeGVCFs {
       GenotypeGVCFs \
       -R ~{ref_fasta} \
       -O ~{output_vcf_filename} \
-      -D ~{dbsnp_vcf} \
+      ~{"-D " + dbsnp_vcf} \
       -G StandardAnnotation -G AS_StandardAnnotation \
       --only-output-calls-starting-in-intervals \
       -V gendb://$WORKSPACE \
@@ -897,7 +897,7 @@ task CrossCheckFingerprint {
   Int cpu = if num_gvcfs < 32 then num_gvcfs else 32
   # Compute memory to use based on the CPU count, following the pattern of
   # 3.75GiB / cpu used by GCP's pricing: https://cloud.google.com/compute/pricing
-  Int memory = if defined(machine_mem_mb) then machine_mem_mb else round(cpu * 3.75 * 1024)
+  Int memory = select_first([machine_mem_mb, round(cpu * 3.75 * 1024)]
   Int java_mem = memory - 512
 
   String output_name = output_base_name + ".fingerprintcheck"

--- a/tasks/broad/JointGenotypingTasks.wdl
+++ b/tasks/broad/JointGenotypingTasks.wdl
@@ -301,7 +301,7 @@ task HardFilterAndMakeSitesOnlyVcf {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -363,7 +363,7 @@ task IndelsVariantRecalibrator {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -431,7 +431,7 @@ task SNPsVariantRecalibratorCreateModel {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -578,7 +578,7 @@ task GatherTranches {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -638,7 +638,7 @@ task ApplyRecalibration {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -685,7 +685,7 @@ task GatherVcfs {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -856,7 +856,7 @@ task GatherVariantCallingMetrics {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1

--- a/tasks/broad/TerraCopyFilesFromCloudToCloud.wdl
+++ b/tasks/broad/TerraCopyFilesFromCloudToCloud.wdl
@@ -41,7 +41,7 @@ task TerraCopyFilesFromCloudToCloud {
 
   runtime {
     memory: "16 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 32 HDD"
     docker: "gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-slim"
     preemptible: 3

--- a/tasks/broad/UnmappedBamToAlignedBam.wdl
+++ b/tasks/broad/UnmappedBamToAlignedBam.wdl
@@ -18,34 +18,22 @@ version 1.0
 
 import "../../tasks/broad/Alignment.wdl" as Alignment
 import "../../tasks/broad/DragmapAlignment.wdl" as DragmapAlignment
-import "../../tasks/broad/SplitLargeReadGroup.wdl" as SplitRG
+import "../../tasks/broad/SplitLargeReadGroup.wdl" as SplitReadGroup
 import "../../tasks/broad/Qc.wdl" as QC
 import "../../tasks/broad/BamProcessing.wdl" as Processing
-import "../../tasks/broad/Utilities.wdl" as Utils
-import "../../structs/dna_seq/DNASeqStructs.wdl" as Structs
+import "../../structs/dna_seq/DNASeqStructs.wdl"
 
 # WORKFLOW DEFINITION
 workflow UnmappedBamToAlignedBam {
 
   input {
     SampleAndUnmappedBams sample_and_unmapped_bams
-    DNASeqSingleSampleReferences references
+    ReferenceFasta reference_fasta
     DragmapReference? dragmap_reference
     PapiSettings papi_settings
 
-    File contamination_sites_ud
-    File contamination_sites_bed
-    File contamination_sites_mu
-
-    String cross_check_fingerprints_by
-    File haplotype_database_file
-    Float lod_threshold
-    String recalibrated_bam_basename
     Boolean hard_clip_reads = false
     Boolean unmap_contaminant_reads = true
-    Boolean bin_base_qualities = true
-    Boolean somatic = false
-    Boolean perform_bqsr = true
     Boolean use_bwa_mem = true
     Boolean allow_empty_ref_alt = false
   }
@@ -76,12 +64,12 @@ workflow UnmappedBamToAlignedBam {
     if (unmapped_bam_size > cutoff_for_large_rg_in_gb) {
       # Split bam into multiple smaller bams,
       # map reads to reference and recombine into one bam
-      call SplitRG.SplitLargeReadGroup as SplitRG {
+      call SplitReadGroup.SplitLargeReadGroup as SplitRG {
         input:
           input_bam = unmapped_bam,
           bwa_commandline = bwa_commandline,
           output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
-          reference_fasta = references.reference_fasta,
+          reference_fasta = reference_fasta,
           dragmap_reference = dragmap_reference,
           compression_level = compression_level,
           preemptible_tries = papi_settings.preemptible_tries,
@@ -100,7 +88,7 @@ workflow UnmappedBamToAlignedBam {
             input_bam = unmapped_bam,
             bwa_commandline = bwa_commandline,
             output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
-            reference_fasta = references.reference_fasta,
+            reference_fasta = reference_fasta,
             compression_level = compression_level,
             preemptible_tries = papi_settings.preemptible_tries,
             hard_clip_reads = hard_clip_reads,
@@ -113,7 +101,7 @@ workflow UnmappedBamToAlignedBam {
           input:
             input_bam = unmapped_bam,
             output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
-            reference_fasta = references.reference_fasta,
+            reference_fasta = reference_fasta,
             dragmap_reference = select_first([dragmap_reference]),
             compression_level = compression_level,
             preemptible_tries = papi_settings.preemptible_tries,
@@ -124,8 +112,6 @@ workflow UnmappedBamToAlignedBam {
     }
 
     File output_aligned_bam = select_first([SamToFastqAndBwaMemAndMba.output_bam, SamToFastqAndDragmapAndMba.output_bam, SplitRG.aligned_bam])
-
-    Float mapped_bam_size = size(output_aligned_bam, "GiB")
 
     # QC the aligned but unsorted readgroup BAM
     # no reference as the input here is unsorted, providing a reference would cause an error
@@ -163,115 +149,6 @@ workflow UnmappedBamToAlignedBam {
       preemptible_tries = if data_too_large_for_preemptibles then 0 else papi_settings.agg_preemptible_tries
   }
 
-  Float agg_bam_size = size(SortSampleBam.output_bam, "GiB")
-
-  if (defined(haplotype_database_file)) {
-    # Check identity of fingerprints across readgroups
-    call QC.CrossCheckFingerprints as CrossCheckFingerprints {
-      input:
-        input_bams = [ SortSampleBam.output_bam ],
-        input_bam_indexes = [SortSampleBam.output_bam_index],
-        haplotype_database_file = haplotype_database_file,
-        metrics_filename = sample_and_unmapped_bams.base_file_name + ".crosscheck",
-        total_input_size = agg_bam_size,
-        lod_threshold = lod_threshold,
-        cross_check_by = cross_check_fingerprints_by,
-        preemptible_tries = papi_settings.agg_preemptible_tries
-    }
-  }
-
-  # Create list of sequences for scatter-gather parallelization
-  call Utils.CreateSequenceGroupingTSV as CreateSequenceGroupingTSV {
-    input:
-      ref_dict = references.reference_fasta.ref_dict,
-      preemptible_tries = papi_settings.preemptible_tries
-  }
-
-  # Estimate level of cross-sample contamination
-  call Processing.CheckContamination as CheckContamination {
-    input:
-      input_bam = SortSampleBam.output_bam,
-      input_bam_index = SortSampleBam.output_bam_index,
-      contamination_sites_ud = contamination_sites_ud,
-      contamination_sites_bed = contamination_sites_bed,
-      contamination_sites_mu = contamination_sites_mu,
-      ref_fasta = references.reference_fasta.ref_fasta,
-      ref_fasta_index = references.reference_fasta.ref_fasta_index,
-      output_prefix = sample_and_unmapped_bams.base_file_name + ".preBqsr",
-      preemptible_tries = papi_settings.agg_preemptible_tries,
-      contamination_underestimation_factor = 0.75
-  }
-
-  # We need disk to localize the sharded input and output due to the scatter for BQSR.
-  # If we take the number we are scattering by and reduce by 3 we will have enough disk space
-  # to account for the fact that the data is not split evenly.
-  Int num_of_bqsr_scatters = length(CreateSequenceGroupingTSV.sequence_grouping)
-  Int potential_bqsr_divisor = num_of_bqsr_scatters - 10
-  Int bqsr_divisor = if potential_bqsr_divisor > 1 then potential_bqsr_divisor else 1
-
-  # Perform Base Quality Score Recalibration (BQSR) on the sorted BAM in parallel
-
-  if (perform_bqsr) {
-    scatter (subgroup in CreateSequenceGroupingTSV.sequence_grouping) {
-      # Generate the recalibration model by interval
-      call Processing.BaseRecalibrator as BaseRecalibrator {
-        input:
-          input_bam = SortSampleBam.output_bam,
-          input_bam_index = SortSampleBam.output_bam_index,
-          recalibration_report_filename = sample_and_unmapped_bams.base_file_name + ".recal_data.csv",
-          sequence_group_interval = subgroup,
-          dbsnp_vcf = references.dbsnp_vcf,
-          dbsnp_vcf_index = references.dbsnp_vcf_index,
-          known_indels_sites_vcfs = references.known_indels_sites_vcfs,
-          known_indels_sites_indices = references.known_indels_sites_indices,
-          ref_dict = references.reference_fasta.ref_dict,
-          ref_fasta = references.reference_fasta.ref_fasta,
-          ref_fasta_index = references.reference_fasta.ref_fasta_index,
-          bqsr_scatter = bqsr_divisor,
-          preemptible_tries = papi_settings.agg_preemptible_tries
-      }
-    }
-
-    # Merge the recalibration reports resulting from by-interval recalibration
-    # The reports are always the same size
-    call Processing.GatherBqsrReports as GatherBqsrReports {
-      input:
-        input_bqsr_reports = BaseRecalibrator.recalibration_report,
-        output_report_filename = sample_and_unmapped_bams.base_file_name + ".recal_data.csv",
-        preemptible_tries = papi_settings.preemptible_tries
-    }
-
-    scatter (subgroup in CreateSequenceGroupingTSV.sequence_grouping_with_unmapped) {
-      # Apply the recalibration model by interval
-      call Processing.ApplyBQSR as ApplyBQSR {
-        input:
-          input_bam = SortSampleBam.output_bam,
-          input_bam_index = SortSampleBam.output_bam_index,
-          output_bam_basename = recalibrated_bam_basename,
-          recalibration_report = GatherBqsrReports.output_bqsr_report,
-          sequence_group_interval = subgroup,
-          ref_dict = references.reference_fasta.ref_dict,
-          ref_fasta = references.reference_fasta.ref_fasta,
-          ref_fasta_index = references.reference_fasta.ref_fasta_index,
-          bqsr_scatter = bqsr_divisor,
-          compression_level = compression_level,
-          preemptible_tries = papi_settings.agg_preemptible_tries,
-          bin_base_qualities = bin_base_qualities,
-          somatic = somatic
-      }
-    }
-  }
-
-  # Merge the recalibrated BAM files resulting from by-interval recalibration
-  call Processing.GatherSortedBamFiles as GatherBamFiles {
-    input:
-      input_bams = select_first([ApplyBQSR.recalibrated_bam, [SortSampleBam.output_bam]]),
-      output_bam_basename = sample_and_unmapped_bams.base_file_name,
-      total_input_size = agg_bam_size,
-      compression_level = compression_level,
-      preemptible_tries = papi_settings.agg_preemptible_tries
-  }
-
   # Outputs that will be retained when execution is complete
   output {
     Array[File] quality_yield_metrics = CollectQualityYieldMetrics.quality_yield_metrics
@@ -285,16 +162,10 @@ workflow UnmappedBamToAlignedBam {
     Array[File] unsorted_read_group_quality_distribution_pdf = CollectUnsortedReadgroupBamQualityMetrics.quality_distribution_pdf
     Array[File] unsorted_read_group_quality_distribution_metrics = CollectUnsortedReadgroupBamQualityMetrics.quality_distribution_metrics
 
-    File? cross_check_fingerprints_metrics = CrossCheckFingerprints.cross_check_fingerprints_metrics
-
-    File selfSM = CheckContamination.selfSM
-    Float contamination = CheckContamination.contamination
-
     File duplicate_metrics = MarkDuplicates.duplicate_metrics
-    File? output_bqsr_reports = GatherBqsrReports.output_bqsr_report
 
-    File output_bam = GatherBamFiles.output_bam
-    File output_bam_index = GatherBamFiles.output_bam_index
+    File output_bam = SortSampleBam.output_bam
+    File output_bam_index = SortSampleBam.output_bam_index
   }
   meta {
     allowNestedInputs: true

--- a/tasks/broad/Utilities.wdl
+++ b/tasks/broad/Utilities.wdl
@@ -149,7 +149,7 @@ task ConvertToCram {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: preemptible_tries
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
@@ -180,7 +180,7 @@ task ConvertToBam {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: 3
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 200 HDD"
   }
   output {

--- a/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl
+++ b/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl
@@ -45,7 +45,7 @@ task BuildBWAreference {
 	 memory: "96GB"
 	 disks: "local-disk 100 HDD"
      disk: "100 GB" # TES
-	 cpu: "4"
+	 cpu: 4
      }
 
      output {


### PR DESCRIPTION
### Description

Two commits

1. Removed inputs that are human-only resource files
   *  e.g. `hapmap_resource_vcf`, `omni_resource_vcf`, etc.
   * Replaced `dbsnp_vcf` with `empty_dbsnp_vcf` to make explicit that only trivial uses of `dbsnp_vcf` will be retained.
   * These changes necessitated removal of variant and base recalibration.
2. Fixed a very common linting error where runtime.cpu was specified as a string.
   * This change is obviously trivial, but it makes it much simpler to process remaining WDL warnings and errors.
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [X] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
