### PR TITLE
Add restore_hardclips option to CramToUnmappedBams

### DIFF
--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -20,6 +20,7 @@ workflow CramToUnmappedBams {
     String base_file_name
     String unmapped_bam_suffix = ".unmapped.bam"
     Int additional_disk = 20
+    Bool restore_hardclips = false
   }
 
   if (defined(input_cram)) {
@@ -68,7 +69,8 @@ workflow CramToUnmappedBams {
       input:
         input_bam = SplitOutUbamByReadGroup.output_bam,
         output_bam_filename = unmapped_bam_filename,
-        disk_size = ceil(input_size * 3) + additional_disk
+        disk_size = ceil(input_size * 3) + additional_disk,
+        restore_hardclips = restore_hardclips,
     }
 
     call SortSam {
@@ -102,6 +104,7 @@ task RevertSam {
     String output_bam_filename
     Int disk_size
     Int memory_in_MiB = 3000
+    Bool restore_hardclips = false
   }
 
   Int java_mem = memory_in_MiB - 1000
@@ -118,6 +121,7 @@ task RevertSam {
     --ATTRIBUTE_TO_CLEAR PA \
     --ATTRIBUTE_TO_CLEAR OA \
     --ATTRIBUTE_TO_CLEAR XA \
+    ~{if restore_hardclips then "--RESTORE_HARDCLIPS" else ""} \
     --SORT_ORDER coordinate
 
   >>>

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -121,7 +121,7 @@ task RevertSam {
     --ATTRIBUTE_TO_CLEAR PA \
     --ATTRIBUTE_TO_CLEAR OA \
     -ATTRIBUTE_TO_CLEAR XA \
-    --RESTORE_HARDCLIPS" ~{restore_hardclips} \
+    --RESTORE_HARDCLIPS ~{restore_hardclips} \
     --SORT_ORDER coordinate
 
   >>>

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -25,8 +25,8 @@ workflow CramToUnmappedBams {
 
   if (defined(input_cram)) {
     Float cram_size = size(input_cram, "GiB")
-    String bam_from_cram_name = basename(input_cram_path, ".cram")
     String input_cram_path = select_first([input_cram])
+    String bam_from_cram_name = basename(input_cram_path, ".cram")
 
     call CramToBam {
       input:
@@ -120,7 +120,7 @@ task RevertSam {
     --ATTRIBUTE_TO_CLEAR CO \
     --ATTRIBUTE_TO_CLEAR PA \
     --ATTRIBUTE_TO_CLEAR OA \
-    --ATTRIBUTE_TO_CLEAR XA \
+    -ATTRIBUTE_TO_CLEAR XA \
     ~{if restore_hardclips then "--RESTORE_HARDCLIPS" else ""} \
     --SORT_ORDER coordinate
 

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -121,7 +121,7 @@ task RevertSam {
     --ATTRIBUTE_TO_CLEAR PA \
     --ATTRIBUTE_TO_CLEAR OA \
     -ATTRIBUTE_TO_CLEAR XA \
-    ~{if restore_hardclips then "--RESTORE_HARDCLIPS" else ""} \
+    --RESTORE_HARDCLIPS" ~{restore_hardclips} \
     --SORT_ORDER coordinate
 
   >>>

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -20,7 +20,7 @@ workflow CramToUnmappedBams {
     String base_file_name
     String unmapped_bam_suffix = ".unmapped.bam"
     Int additional_disk = 20
-    Bool restore_hardclips = false
+    Boolean restore_hardclips = true
   }
 
   if (defined(input_cram)) {
@@ -104,7 +104,7 @@ task RevertSam {
     String output_bam_filename
     Int disk_size
     Int memory_in_MiB = 3000
-    Bool restore_hardclips = false
+    Boolean restore_hardclips = true
   }
 
   Int java_mem = memory_in_MiB - 1000
@@ -120,7 +120,7 @@ task RevertSam {
     --ATTRIBUTE_TO_CLEAR CO \
     --ATTRIBUTE_TO_CLEAR PA \
     --ATTRIBUTE_TO_CLEAR OA \
-    -ATTRIBUTE_TO_CLEAR XA \
+    --ATTRIBUTE_TO_CLEAR XA \
     --RESTORE_HARDCLIPS ~{restore_hardclips} \
     --SORT_ORDER coordinate
 


### PR DESCRIPTION
Add `restore_hardclips` option to CramToUnmappedBams, which invokes `--RESTORE_HARDCLIPS` in call to `picard RevertSam`. This option defaults to `false` to retain original behavior.
